### PR TITLE
Same Ship Fix

### DIFF
--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -71,4 +71,20 @@ public class Game {
 	        return false;
    	    }
    }
+
+    /**
+     * Returns the player's current board
+     * @return Board
+     */
+   public Board getPlayersBoard() {
+        return playersBoard;
+   }
+
+    /**
+     * Returns the opponent's board
+     * @return board
+     */
+   public Board getOpponentsBoard() {
+        return opponentsBoard;
+   }
 }

--- a/src/main/java/cs361/battleships/models/Game.java
+++ b/src/main/java/cs361/battleships/models/Game.java
@@ -20,11 +20,14 @@ public class Game {
         if (!successful)
             return false;
 
+        // setup a new ship for the bot
+        Ship s2 = new Ship(ship.getShipType());
+
         boolean opponentPlacedSuccessfully;
         do {
             // AI places random ships, so it might try and place overlapping ships
             // let it try until it gets it right
-            opponentPlacedSuccessfully = opponentsBoard.placeShip(ship, randRow(), randCol(), randVertical());
+            opponentPlacedSuccessfully = opponentsBoard.placeShip(s2, randRow(), randCol(), randVertical());
         } while (!opponentPlacedSuccessfully);
 
         return true;

--- a/src/test/java/cs361/battleships/models/GameTest.java
+++ b/src/test/java/cs361/battleships/models/GameTest.java
@@ -1,9 +1,13 @@
 package cs361.battleships.models;
 
 import org.junit.Test;
+
+import java.util.List;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 
 public class GameTest {
@@ -63,6 +67,27 @@ public class GameTest {
         // attack the space with this ship now
         assertTrue(g.attack(1,'A'));
 
+    }
+
+    /**
+     * Ensures player & bot ships are not accidentally the same
+     */
+    @Test
+    public void testPlayerAndBotShipsIndependent() {
+        Game g = new Game();
+        g.placeShip(new Ship("MINESWEEPER"), 5,'B',true);
+
+        // get the player's ship
+        Board b1 = g.getPlayersBoard();
+        List<Ship> playerShips = b1.getShips();
+        Ship playerShip = playerShips.get(0);
+
+        // get the bot's ship
+        Board b2 = g.getOpponentsBoard();
+        List<Ship> botShips = b2.getShips();
+        Ship botShip = botShips.get(0);
+
+        assertNotEquals(playerShip, botShip);
     }
 
 }


### PR DESCRIPTION
Fixes #17, which was caused by the same 'ship' object being used for both boards. Objects are passed by reference in this case, not by value, leading the last modifications to 'ship' taking precedence over the others. This meant that the random positions for the bot were the final positions, and we were just looking at the same object that would be on both boards.