### PR TITLE
Adds Class UML (After)

### DIFF
--- a/UMLs/Class_UML_After.mdj
+++ b/UMLs/Class_UML_After.mdj
@@ -1,0 +1,8482 @@
+{
+	"_type": "Project",
+	"_id": "AAAAAAFF+h6SjaM2Hec=",
+	"name": "Untitled",
+	"ownedElements": [
+		{
+			"_type": "UMLModel",
+			"_id": "AAAAAAFF+qBWK6M3Z8Y=",
+			"_parent": {
+				"$ref": "AAAAAAFF+h6SjaM2Hec="
+			},
+			"name": "Model",
+			"ownedElements": [
+				{
+					"_type": "UMLClassDiagram",
+					"_id": "AAAAAAFF+qBtyKM79qY=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Main",
+					"defaultDiagram": true,
+					"ownedViews": [
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKfWFh4wMF3A=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKfWFiIwNeH8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfWFh4wMF3A="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfWFhowKE2I="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfWFiYwOK+Q=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiIwNeH8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 240,
+											"top": -144,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfWFiYwPkac=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiIwNeH8="
+											},
+											"font": "Arial;13;1",
+											"left": 309,
+											"top": 31,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "Ship"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfWFiYwQF38=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiIwNeH8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 240,
+											"top": -144,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfWFiYwRxso=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiIwNeH8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 240,
+											"top": -144,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 304,
+									"top": 24,
+									"width": 160.64892578125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKfWFiYwOK+Q="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKfWFiYwPkac="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKfWFiYwQF38="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKfWFiYwRxso="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKfWFiYwSNf0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfWFh4wMF3A="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfWFhowKE2I="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKfnKXYxBc6I=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwSNf0="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfnKPIw+gHs="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 54,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+Health",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKfnhJYxIAWk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwSNf0="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfng/YxFqIk="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 69,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+length",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKfofEIxPUAw=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwSNf0="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfoe7YxMLvk="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 84,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+armor",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKfpiI4xYRg4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwSNf0="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfph/oxVIE0="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 99,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+shipType",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 304,
+									"top": 49,
+									"width": 160.64892578125,
+									"height": 68
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKfWFiYwT4OI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfWFh4wMF3A="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfWFhowKE2I="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfqju4xoFnk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfqjl4xl9rs="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 122,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+Ship()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfq9EIxvExY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfq854xsm80="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 137,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+Ship(kind)",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfu+Sox4/JI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfu+J4x1NAg="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 152,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+getOccupiedSquares()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfvieIx/YRw=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfviT4x864A="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 167,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+setOccupiedSquares()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfwHx4yGj5g=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfwHn4yDk2g="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 182,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+getLength()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfwjEoyNt44=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfwi8IyK5m8="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 197,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+getShipType()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfw9Y4yU7b4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfw9OoyRT8U="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 212,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+decrementHealth()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfxzioym7do=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfxzaIyjlPo="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 227,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+forceSink()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfyB3YytY58=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfyBtIyqOFE="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 242,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+getHealth()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfyQl4y0oxM=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfyQb4yx8bw="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 257,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+setArmor()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfygD4y7Jek=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfyf4oy4RCw="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 272,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+getArmor()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKfyu04zCkow=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKfyuqoy/mUU="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 287,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+Operation1()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYThJLuDwCe8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYThJE+DtYgs="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 302,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+canAttackWithWeapon()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUz+Blwf4b8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfWFiYwT4OI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUz941wcd/U="
+											},
+											"font": "Arial;13;0",
+											"left": 309,
+											"top": 317,
+											"width": 150.64892578125,
+											"height": 13,
+											"text": "+checkAndUpdateForHit()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 304,
+									"top": 117,
+									"width": 160.64892578125,
+									"height": 218
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKfWFiYwULH4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfWFh4wMF3A="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfWFhowKE2I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1024,
+									"top": -16,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKfWFiowVX04=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfWFh4wMF3A="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfWFhowKE2I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1024,
+									"top": -16,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 304,
+							"top": 24,
+							"width": 160.64892578125,
+							"height": 311,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKfWFiIwNeH8="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKfWFiYwSNf0="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKfWFiYwT4OI="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKfWFiYwULH4="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKfWFiowVX04="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKfzYa4zHr90=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfzYa4zFWdM="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKfzYa4zIIh8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzYa4zHr90="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzYa4zFWdM="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzYa4zJD8A=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzYa4zIIh8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": -508,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzYa4zK4kM=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzYa4zIIh8="
+											},
+											"font": "Arial;13;1",
+											"left": 29,
+											"top": 199,
+											"width": 93.564453125,
+											"height": 13,
+											"text": "Minesweeper"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzYa4zLF44=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzYa4zIIh8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": -508,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzYa4zM9aU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzYa4zIIh8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": -508,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 192,
+									"width": 103.564453125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKfzYa4zJD8A="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKfzYa4zK4kM="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKfzYa4zLF44="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKfzYa4zM9aU="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKfzYa4zNnjk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzYa4zHr90="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzYa4zFWdM="
+									},
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 217,
+									"width": 103.564453125,
+									"height": 10
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKfzYbIzOv4s=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzYa4zHr90="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzYa4zFWdM="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgERzo2Q/EM=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzYbIzOv4s="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgERqY2Nloo="
+											},
+											"font": "Arial;13;0",
+											"left": 29,
+											"top": 232,
+											"width": 93.564453125,
+											"height": 13,
+											"text": "+Minesweeper()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 227,
+									"width": 103.564453125,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKfzYbIzPFX4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzYa4zHr90="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzYa4zFWdM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 784,
+									"top": -302,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKfzYbIzQwio=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzYa4zHr90="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzYa4zFWdM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 784,
+									"top": -302,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 24,
+							"top": 192,
+							"width": 103.564453125,
+							"height": 75,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKfzYa4zIIh8="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKfzYa4zNnjk="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKfzYbIzOv4s="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKfzYbIzPFX4="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKfzYbIzQwio="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnKfzY1YzwG4g=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfzY1Yzu31o="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzY1ozxsWA=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzY1Yzu31o="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 212,
+									"top": 185,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzY1ozy4QQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzY1Yzu31o="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 210,
+									"top": 170,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzY1ozzZ0s=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzY1Yzu31o="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 217,
+									"top": 214,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzY1YzwG4g="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKfzYa4zHr90="
+							},
+							"lineStyle": 1,
+							"points": "128:220;303:192",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKfzY1ozxsWA="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKfzY1ozy4QQ="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKfzY1ozzZ0s="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKfzzg40BR7Q=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfzzg4z/MyY="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKfzzg40CXnQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzzg40BR7Q="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzzg4z/MyY="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzzg40Daho=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzzg40CXnQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -441.83984375,
+											"top": -652,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzzg40EfzI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzzg40CXnQ="
+											},
+											"font": "Arial;13;1",
+											"left": 29,
+											"top": 127,
+											"width": 80.57080078125,
+											"height": 13,
+											"text": "Battleship"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzzg40FSxQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzzg40CXnQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -441.83984375,
+											"top": -652,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfzzg40GGSE=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzzg40CXnQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -441.83984375,
+											"top": -652,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 120,
+									"width": 90.57080078125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKfzzg40Daho="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKfzzg40EfzI="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKfzzg40FSxQ="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKfzzg40GGSE="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKfzzg40HwDQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzzg40BR7Q="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzzg4z/MyY="
+									},
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 145,
+									"width": 90.57080078125,
+									"height": 10
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKfzzg40I0Wg=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzzg40BR7Q="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzzg4z/MyY="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgEDFo2JjMk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfzzg40I0Wg="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgEC8Y2GRS8="
+											},
+											"font": "Arial;13;0",
+											"left": 29,
+											"top": 160,
+											"width": 80.57080078125,
+											"height": 13,
+											"text": "+Battleship()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 24,
+									"top": 155,
+									"width": 90.57080078125,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKfzzg40J/Dg=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzzg40BR7Q="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzzg4z/MyY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 627.080078125,
+									"top": -358,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKfzzg40K+jI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzzg40BR7Q="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzzg4z/MyY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 627.080078125,
+									"top": -358,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 24,
+							"top": 120,
+							"width": 90.57080078125,
+							"height": 58,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKfzzg40CXnQ="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKfzzg40HwDQ="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKfzzg40I0Wg="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKfzzg40J/Dg="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKfzzg40K+jI="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnKfzz9o0qIzc=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfzz9o0o4bA="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzz9o0rU2Y=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzz9o0o4bA="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 210,
+									"top": 141,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzz9o0sJ3A=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzz9o0o4bA="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 211,
+									"top": 126,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfzz9o0tMwI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfzz9o0o4bA="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 207,
+									"top": 170,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfzz9o0qIzc="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKfzzg40BR7Q="
+							},
+							"lineStyle": 1,
+							"points": "115:153;303:171",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKfzz9o0rU2Y="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKfzz9o0sJ3A="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKfzz9o0tMwI="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKfz1Eo07iyg=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfz1Eo05V4c="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKfz1Eo08Sqc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1Eo07iyg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1Eo05V4c="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfz1Eo09sO0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfz1Eo08Sqc="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -547.6796875,
+											"top": -300,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfz1Eo0+hK8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfz1Eo08Sqc="
+											},
+											"font": "Arial;13;1",
+											"left": 37,
+											"top": 303,
+											"width": 79,
+											"height": 13,
+											"text": "Destroyer"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfz1E40/fCU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfz1Eo08Sqc="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -547.6796875,
+											"top": -300,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKfz1E41A0kc=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfz1Eo08Sqc="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -547.6796875,
+											"top": -300,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 32,
+									"top": 296,
+									"width": 89,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKfz1Eo09sO0="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKfz1Eo0+hK8="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKfz1E40/fCU="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKfz1E41A0kc="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKfz1E41BGw0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1Eo07iyg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1Eo05V4c="
+									},
+									"font": "Arial;13;0",
+									"left": 32,
+									"top": 321,
+									"width": 89,
+									"height": 10
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKfz1E41CXok=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1Eo07iyg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1Eo05V4c="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgDPd42B3KI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKfz1E41CXok="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgDPUY1+Xf8="
+											},
+											"font": "Arial;13;0",
+											"left": 37,
+											"top": 336,
+											"width": 79,
+											"height": 13,
+											"text": "+Destroyer()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 32,
+									"top": 331,
+									"width": 89,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKfz1E41DRnI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1Eo07iyg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1Eo05V4c="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 558.16015625,
+									"top": -174,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKfz1E41Eh1c=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1Eo07iyg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1Eo05V4c="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 558.16015625,
+									"top": -174,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 32,
+							"top": 296,
+							"width": 89,
+							"height": 65,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKfz1Eo08Sqc="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKfz1E41BGw0="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKfz1E41CXok="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKfz1E41DRnI="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKfz1E41Eh1c="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnKfz1eo1kyAE=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKfz1eo1iepg="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfz1eo1lq1A=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1eo1iepg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 205,
+									"top": 242,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfz1eo1msvc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1eo1iepg="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 198,
+									"top": 228,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKfz1eo1nu3s=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKfz1eo1iepg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 218,
+									"top": 269,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKfz1eo1kyAE="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKfz1Eo07iyg="
+							},
+							"lineStyle": 1,
+							"points": "121:306;303:218",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKfz1eo1lq1A="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKfz1eo1msvc="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKfz1eo1nu3s="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKgZYZ42eDo0=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKgZYZ42fofs=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgZYZ42eDo0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKgZYZ42c42w="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKgZYZ42gKzE=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42fofs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -1424,
+											"top": 800,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKgZYZ42hKu0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42fofs="
+											},
+											"font": "Arial;13;1",
+											"left": 5,
+											"top": 511,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "Square"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKgZYZ42ieAA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42fofs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -1424,
+											"top": 800,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKgZYZ42jwyY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42fofs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -1424,
+											"top": 800,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"top": 504,
+									"width": 167.16162109375,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKgZYZ42gKzE="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKgZYZ42hKu0="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKgZYZ42ieAA="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKgZYZ42jwyY="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKgZYZ42kwSA=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgZYZ42eDo0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKgZYZ42c42w="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKgZxhI3Jp4c=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42kwSA="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgZxWI3GcGo="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 534,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "-Row",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKgaDAo3QhzA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42kwSA="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgaC1I3NW14="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 549,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "-Column",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKgaY5o3X4LA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42kwSA="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgaYuo3UIUY="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 564,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "-Captain",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"top": 529,
+									"width": 167.16162109375,
+									"height": 53
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKgZYZ42lj2c=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgZYZ42eDo0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKgZYZ42c42w="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgbc6o3l9KQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgbcwY3i3uk="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 587,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+Square(default)",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgb4ro3rNLA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgb4iI3opzs="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 602,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+Square()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgd78Y32W6w=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgd7yY3zmIU="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 617,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+getColumn()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgeUyY39Dyo=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgeUlY36abw="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 632,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+setColumn()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgeuN44EC6g=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgeuAY4Buv8="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 647,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+setCaptainsQuarters()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgfN9Y4Lx7U=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgfNyI4IZac="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 662,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+getRow()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKgf9gY4V1Qo=",
+											"_parent": {
+												"$ref": "AAAAAAFnKgZYZ42lj2c="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKgf9T44S3ns="
+											},
+											"font": "Arial;13;0",
+											"left": 5,
+											"top": 677,
+											"width": 157.16162109375,
+											"height": 13,
+											"text": "+setRow()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"top": 582,
+									"width": 167.16162109375,
+									"height": 113
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKgZYaI2mmlI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgZYZ42eDo0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKgZYZ42c42w="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -640,
+									"top": 400,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKgZYaI2nynw=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgZYZ42eDo0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKgZYZ42c42w="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -640,
+									"top": 400,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"top": 504,
+							"width": 167.16162109375,
+							"height": 206,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKgZYZ42fofs="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKgZYZ42kwSA="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKgZYZ42lj2c="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKgZYaI2mmlI="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKgZYaI2nynw="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKhoADY6po7o=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKhoADY6q7zg=",
+									"_parent": {
+										"$ref": "AAAAAAFnKhoADY6po7o="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKhoADY6nCLQ="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKhoADY6rQS4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6q7zg="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 576,
+											"top": -720,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKhoADY6s4KU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6q7zg="
+											},
+											"font": "Arial;13;1",
+											"left": 1141,
+											"top": 39,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "Game"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKhoADY6tT9w=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6q7zg="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 576,
+											"top": -720,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKhoADY6uSmg=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6q7zg="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 576,
+											"top": -720,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 1136,
+									"top": 32,
+									"width": 142.615234375,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKhoADY6rQS4="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKhoADY6s4KU="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKhoADY6tT9w="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKhoADY6uSmg="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKhoADY6vrWI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKhoADY6po7o="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKhoADY6nCLQ="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKhovA47Uqww=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6vrWI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhou3I7R4Yw="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 62,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "-playersBoard",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKhpX847b6wg=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6vrWI="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhpXxI7Yxf4="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 77,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "-opponentsBoard",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 1136,
+									"top": 57,
+									"width": 142.615234375,
+									"height": 38
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKhoADY6wEzM=",
+									"_parent": {
+										"$ref": "AAAAAAFnKhoADY6po7o="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKhoADY6nCLQ="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhqKno7jy/g=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhqKdY7g//M="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 100,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+placeShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhqbGY7qN/Y=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhqa5o7naUM="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 115,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+attack()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhquU47xJPk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhquKY7uu1c="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 130,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+sonar()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhrCk474RWA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhrCaI71DDI="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 145,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+randCol()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhrOqo7/rVE=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhrOfI78JWE="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 160,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+randRow()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhsiHY8GMC8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhsh948DWkk="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 175,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+randVertical()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhs1To8NVkw=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhs1II8KW8I="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 190,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+getPlayersBoard()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKhtZQo8UuVQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKhtZFo8Ryaw="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 205,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+getOpponentsBoard()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYTl2DegmgRo=",
+											"_parent": {
+												"$ref": "AAAAAAFnKhoADY6wEzM="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTl17+gj2XM="
+											},
+											"font": "Arial;13;0",
+											"left": 1141,
+											"top": 220,
+											"width": 132.615234375,
+											"height": 13,
+											"text": "+moveFleet()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 1136,
+									"top": 95,
+									"width": 142.615234375,
+									"height": 143
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKhoADo6xolw=",
+									"_parent": {
+										"$ref": "AAAAAAFnKhoADY6po7o="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKhoADY6nCLQ="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -1080,
+									"top": -392,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKhoADo6yG9A=",
+									"_parent": {
+										"$ref": "AAAAAAFnKhoADY6po7o="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKhoADY6nCLQ="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -1080,
+									"top": -392,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 1136,
+							"top": 32,
+							"width": 142.615234375,
+							"height": 221,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKhoADY6q7zg="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKhoADY6vrWI="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKhoADY6wEzM="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKhoADo6xolw="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKhoADo6yG9A="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKiU9E491Jgc=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKiU9E4927SA=",
+									"_parent": {
+										"$ref": "AAAAAAFnKiU9E491Jgc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKiU9E49z87Q="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKiU9E4932nA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4927SA="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -352,
+											"top": -256,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKiU9E4943BY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4927SA="
+											},
+											"font": "Arial;13;1",
+											"left": 397,
+											"top": 383,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "Board"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKiU9E495EcA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4927SA="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -352,
+											"top": -256,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKiU9E496AOA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4927SA="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -352,
+											"top": -256,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 392,
+									"top": 376,
+									"width": 232.16162109375,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKiU9E4932nA="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKiU9E4943BY="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKiU9E495EcA="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKiU9E496AOA="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKiU9E4977VQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKiU9E491Jgc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKiU9E49z87Q="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiWXbo+i5e8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiWXRI+fqd8="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 406,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-boardarray",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiWtl4+ptZ4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiWtYo+mjeg="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 421,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-occupied",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiXNS4+wLI0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiXNG4+t/Bs="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 436,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-sonarEnabled",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiX6Bo+4GrY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiX51o+1J6k="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 451,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-sonarCount",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiYXgo+/xto=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiYXU4+8jNg="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 466,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+BOARDSIZE_X",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiZAnY/GUqA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiZAbY/Dmcc="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 481,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+BOARDSIZE_Y",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiZO2I/NEaQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiZOp4/KnKg="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 496,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-ships",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKiZkXI/UIl4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiZkJI/Ra7c="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 511,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+attacks",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnYTFQ2L6GHIA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9E4977VQ="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTFQs76DMLU="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 526,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-currentWeapon",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 392,
+									"top": 401,
+									"width": 232.16162109375,
+									"height": 143
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKiU9FI98628=",
+									"_parent": {
+										"$ref": "AAAAAAFnKiU9E491Jgc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKiU9E49z87Q="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKiapf4/kswk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiapVY/hxqM="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 549,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+Board()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKibKRY/rGqs=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKibKEY/oYAk="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 564,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+areCoordinatesOnBoard()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKib5YI/ycV0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKib5LI/v4Y4="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 579,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+isOccupied()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKicaRY/5P7w=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKicaDY/2dWU="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 594,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getSquare()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKicm7ZAAoVk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKicmu4/9xVU="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 609,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+placeShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKic3F5AHJ+0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKic26JAEo+4="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 624,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+attack()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKidDG5AOcaA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKidC65ALMOk="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 639,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+sonar()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKidVTpAVcM0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKidVH5ASE7A="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 654,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getShips()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKidknpAc24U=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKidkYJAZK6Y="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 669,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setShips()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKidyqZAj9Sg=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKidyeZAg4Ew="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 684,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+addShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKieeZZArdfQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKieeNpAodGc="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 699,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+removeShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKie1GpAyBCY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKie06ZAvZVY="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 714,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getAttacks()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKifKwpA5mMo=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKifKkJA2Diw="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 729,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+addAttack()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKifhG5BAqyI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKifg4JA96Ho="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 744,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+addAttacks()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKif+3ZBH3V0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKif+qpBEbJw="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 759,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setAttacks()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKigfN5BOftc=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKigfBpBLjSc="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 774,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-setOccupied()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKig7t5BVKNs=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKig7h5BSysE="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 789,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setSonarEnabled()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKihTJZBcACM=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKihS8pBZvMU="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 804,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getSonarEnabled()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKih885Bk3ec=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKih8w5Bhgj0="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 819,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setSonarCount()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKiiR6pBrBGk=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKiiRuZBohSo="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 834,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getSonarCount()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYTqW0wGhYu8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTqWsgGebiM="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 849,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getCurrentWeapon()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYTq+WANYKEY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTq+NQNV5B0="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 864,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setCurrentWeapon()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUSaKSradRI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUSaCCrX3yk="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 879,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-checkToMakeCaptainsQuarters()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUTRMCyRJDw=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUTRDyyOCYo="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 894,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-is_duplicate_ship()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUT53y5IreE=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUT5vy5FFRM="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 909,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-getSonarHitSquare()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUfInUohlPY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKiU9FI98628="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUfIeUoeMYI="
+											},
+											"font": "Arial;13;0",
+											"left": 397,
+											"top": 924,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+moveFleet()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 392,
+									"top": 544,
+									"width": 232.16162109375,
+									"height": 398
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKiU9FI99oqs=",
+									"_parent": {
+										"$ref": "AAAAAAFnKiU9E491Jgc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKiU9E49z87Q="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -232,
+									"top": 336,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKiU9FI9+kaw=",
+									"_parent": {
+										"$ref": "AAAAAAFnKiU9E491Jgc="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKiU9E49z87Q="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -232,
+									"top": 336,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 392,
+							"top": 376,
+							"width": 232.16162109375,
+							"height": 611,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKiU9E4927SA="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKiU9E4977VQ="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKiU9FI98628="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKiU9FI99oqs="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKiU9FI9+kaw="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKi5XFJByAvs=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKi5XE5Bw7yY="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKi5XFJBzovM=",
+									"_parent": {
+										"$ref": "AAAAAAFnKi5XFJByAvs="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKi5XE5Bw7yY="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKi5XFJB0PIU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKi5XFJBzovM="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 304,
+											"top": 1440,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKi5XFJB12wM=",
+											"_parent": {
+												"$ref": "AAAAAAFnKi5XFJBzovM="
+											},
+											"font": "Arial;13;1",
+											"left": 941,
+											"top": 1143,
+											"width": 80.57080078125,
+											"height": 13,
+											"text": "AttackStatus"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKi5XFJB2TDE=",
+											"_parent": {
+												"$ref": "AAAAAAFnKi5XFJBzovM="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 304,
+											"top": 1440,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKi5XFJB3bm4=",
+											"_parent": {
+												"$ref": "AAAAAAFnKi5XFJBzovM="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 304,
+											"top": 1440,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 1136,
+									"width": 90.57080078125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKi5XFJB0PIU="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKi5XFJB12wM="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKi5XFJB2TDE="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKi5XFJB3bm4="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKi5XFJB4aV4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKi5XFJByAvs="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKi5XE5Bw7yY="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKi6Tb5Cdkac=",
+											"_parent": {
+												"$ref": "AAAAAAFnKi5XFJB4aV4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKi6TQ5CaYuI="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 1166,
+											"width": 80.57080078125,
+											"height": 13,
+											"text": "+AttackStatus",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 1161,
+									"width": 90.57080078125,
+									"height": 23
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKi5XFJB5ehI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKi5XFJByAvs="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKi5XE5Bw7yY="
+									},
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 1184,
+									"width": 90.57080078125,
+									"height": 10
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKi5XFJB6F/w=",
+									"_parent": {
+										"$ref": "AAAAAAFnKi5XFJByAvs="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKi5XE5Bw7yY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -440,
+									"top": 728,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKi5XFJB76x4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKi5XFJByAvs="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKi5XE5Bw7yY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -440,
+									"top": 728,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 936,
+							"top": 1136,
+							"width": 90.57080078125,
+							"height": 58,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKi5XFJBzovM="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKi5XFJB4aV4="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKi5XFJB5ehI="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKi5XFJB6F/w="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKi5XFJB76x4="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnKjVWdZCkax0=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnKjVWdZClYkk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKjVWdZCkax0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKjVWdZCibOY="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKjVWdZCmv8E=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdZClYkk="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 64,
+											"top": 672,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKjVWdpCne64=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdZClYkk="
+											},
+											"font": "Arial;13;1",
+											"left": 941,
+											"top": 751,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "Result"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKjVWdpCoIYw=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdZClYkk="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 64,
+											"top": 672,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnKjVWdpCpfIA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdZClYkk="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": 64,
+											"top": 672,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 744,
+									"width": 232.16162109375,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnKjVWdZCmv8E="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnKjVWdpCne64="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnKjVWdpCoIYw="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnKjVWdpCpfIA="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnKjVWdpCqcro=",
+									"_parent": {
+										"$ref": "AAAAAAFnKjVWdZCkax0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKjVWdZCibOY="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKjm3ipDPdyU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCqcro="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjm3XJDMVuM="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 774,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-attackStatus",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKjnOuZDWqiI=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCqcro="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjnOhZDTvsc="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 789,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "-sShip",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnKjn9j5DdfhY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCqcro="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjn9TpDa5LE="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 804,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+loc",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 769,
+									"width": 232.16162109375,
+									"height": 53
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnKjVWdpCrpF4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKjVWdZCkax0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKjVWdZCibOY="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjpBjZDmYcU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjpBXZDjufU="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 827,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getResult()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjpUY5DtS4c=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjpUMpDqO9Y="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 842,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setResult()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjpit5D0lfA=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjpihJDxUUY="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 857,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjqRTpD8TX8=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjqRGZD5/yk="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 872,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setShip()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjqcQ5EDrAY=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjqcDpEAFVo="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 887,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+getLocation()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnKjq6mpEKZi0=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnKjq6X5EH0yw="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 902,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+setLocation()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUrDD1b73Qo=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUrC71b4uEQ="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 917,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+isResultSpaceAlreadyAttacked()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYUs0gVj6ahU=",
+											"_parent": {
+												"$ref": "AAAAAAFnKjVWdpCrpF4="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYUs0XFj3ZdU="
+											},
+											"font": "Arial;13;0",
+											"left": 941,
+											"top": 932,
+											"width": 222.16162109375,
+											"height": 13,
+											"text": "+wasSpaceFormerlyArmoredCaptain()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 936,
+									"top": 822,
+									"width": 232.16162109375,
+									"height": 128
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnKjVWdpCsOSk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKjVWdZCkax0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKjVWdZCibOY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 824,
+									"top": 1512,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnKjVWdpCt9Sc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKjVWdZCkax0="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKjVWdZCibOY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 824,
+									"top": 1512,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 936,
+							"top": 744,
+							"width": 232.16162109375,
+							"height": 206,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnKjVWdZClYkk="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnKjVWdpCqcro="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnKjVWdpCrpF4="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnKjVWdpCsOSk="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnKjVWdpCt9Sc="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKlDm9ZWuwLk=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKlDm9ZWqgrU="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZWvFV0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWqgrU="
+									},
+									"font": "Arial;13;0",
+									"left": 759,
+									"top": 120,
+									"width": 236.6533203125,
+									"height": 13,
+									"alpha": 0.07371235513447455,
+									"distance": 325.8849490234245,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 1,
+									"text": "+The Game creates two separate boards"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZWwNvs=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWqgrU="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 552,
+									"top": 114,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZWxqU0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWqgrU="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 552,
+									"top": 159,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZWyi98=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWr24Y="
+									},
+									"font": "Arial;13;0",
+									"left": 530,
+									"top": 344,
+									"width": 14.82177734375,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 2,
+									"text": "+2"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZWzLXk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWr24Y="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 523,
+									"top": 341,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZW0RHY=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWr24Y="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 564,
+									"top": 348,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZW1+98=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWsajo="
+									},
+									"font": "Arial;13;0",
+									"left": 1103,
+									"top": 129,
+									"width": 14.82177734375,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"text": "+1"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZW25q8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWsajo="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1107,
+									"top": 115,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKlDm9ZW39K8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWsajo="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1114,
+									"top": 156,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKlDm9pW4LrM=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWr24Y="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 792,
+									"top": 472,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKlDm9pW5YzU=",
+									"_parent": {
+										"$ref": "AAAAAAFnKlDm9ZWuwLk="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKlDm9ZWsajo="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 792,
+									"top": 472,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKhoADY6po7o="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKiU9E491Jgc="
+							},
+							"points": "552:376;552:150;1136:150",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKlDm9ZWvFV0="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKlDm9ZWwNvs="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKlDm9ZWxqU0="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKlDm9ZWyi98="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKlDm9ZWzLXk="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKlDm9ZW0RHY="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKlDm9ZW1+98="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKlDm9ZW25q8="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKlDm9ZW39K8="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKlDm9pW4LrM="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKlDm9pW5YzU="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKnzfMtAvrJg=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKnzfMtAr67k="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtAws58=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAr67k="
+									},
+									"font": "Arial;13;0",
+									"left": 703,
+									"top": 741,
+									"width": 170.64404296875,
+									"height": 13,
+									"alpha": 4.493719505099046,
+									"distance": 18.439088914585774,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 1,
+									"text": "+Board creates a result array."
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtAxk7w=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAr67k="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 770,
+									"top": 786,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtAykaI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAr67k="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 783,
+									"top": 743,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtAzJ9Y=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAs8+M="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 905,
+									"top": 811,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtA01a4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAs8+M="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 899,
+									"top": 823,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtA1zeg=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAs8+M="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 917,
+									"top": 786,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtA2yMY=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAtA94="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 644,
+									"top": 732,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtA3piw=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAtA94="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 642,
+									"top": 746,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKnzfMtA4Di4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAtA94="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 648,
+									"top": 705,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKnzfMtA5rRE=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAs8+M="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 208,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKnzfMtA61m4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKnzfMtAvrJg="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKnzfMtAtA94="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 208,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKiU9E491Jgc="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKjVWdZCkax0="
+							},
+							"lineStyle": 1,
+							"points": "935:811;624:717",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKnzfMtAws58="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKnzfMtAxk7w="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKnzfMtAykaI="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKnzfMtAzJ9Y="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKnzfMtA01a4="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKnzfMtA1zeg="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKnzfMtA2yMY="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKnzfMtA3piw="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKnzfMtA4Di4="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKnzfMtA5rRE="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKnzfMtA61m4="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKpNt3tpBLp4=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKpNt3do9VLg="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpCOC4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3do9VLg="
+									},
+									"font": "Arial;13;0",
+									"left": 44,
+									"top": 364,
+									"width": 162.95703125,
+									"height": 13,
+									"alpha": 1.3255659743808519,
+									"distance": 178,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 1,
+									"text": "+Ships are made of squares"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpDBAI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3do9VLg="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 243,
+									"top": 455,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpE5G4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3do9VLg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 286,
+									"top": 471,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpFRn0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to+IEw="
+									},
+									"font": "Arial;13;0",
+									"left": 164,
+									"top": 512,
+									"width": 30.71630859375,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 2,
+									"text": "+2...*"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpGsSQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to+IEw="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 173,
+									"top": 500,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpHw/s=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to+IEw="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 191,
+									"top": 537,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpIWW0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to/dS0="
+									},
+									"font": "Arial;13;0",
+									"left": 293,
+									"top": 347,
+									"width": 14.82177734375,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"text": "+1"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpJN6g=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to/dS0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 287,
+									"top": 345,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpNt3tpKLAo=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to/dS0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 328,
+									"top": 353,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpNt3tpLD8I=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to+IEw="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpNt3tpMfI8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpNt3tpBLp4="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpNt3to/dS0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKgZYZ42eDo0="
+							},
+							"lineStyle": 1,
+							"points": "167:546;272:472;324:335",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKpNt3tpCOC4="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKpNt3tpDBAI="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKpNt3tpE5G4="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKpNt3tpFRn0="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKpNt3tpGsSQ="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpNt3tpHw/s="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKpNt3tpIWW0="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKpNt3tpJN6g="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpNt3tpKLAo="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpNt3tpLD8I="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpNt3tpMfI8="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKpS9pd1iKgU=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKpS9pd1eZ44="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1jIk0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1eZ44="
+									},
+									"font": "Arial;13;0",
+									"left": 127,
+									"top": 737,
+									"width": 155.72705078125,
+									"height": 13,
+									"alpha": -2.0166030798815346,
+									"distance": 127.94530081249565,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 1,
+									"text": "+Board is made of squares"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1kRdQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1eZ44="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 284,
+									"top": 604,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1l+dU=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1eZ44="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 276,
+									"top": 648,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1maY8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1fByg="
+									},
+									"font": "Arial;13;0",
+									"left": 174,
+									"top": 604,
+									"width": 43.01171875,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 2,
+									"text": "+10x10"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1neL8=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1fByg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 199,
+									"top": 591,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1oCcY=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1fByg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 186,
+									"top": 631,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1pO9o=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1gns0="
+									},
+									"font": "Arial;13;0",
+									"left": 360,
+									"top": 634,
+									"width": 14.82177734375,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"text": "+1"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1qejo=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1gns0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 367,
+									"top": 621,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpS9pd1raoc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1gns0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 367,
+									"top": 662,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpS9pd1sGNY=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1fByg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpS9pd1t/jM=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpS9pd1iKgU="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpS9pd1gns0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKiU9E491Jgc="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKgZYZ42eDo0="
+							},
+							"lineStyle": 1,
+							"points": "167:621;391:660",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKpS9pd1jIk0="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKpS9pd1kRdQ="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKpS9pd1l+dU="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKpS9pd1maY8="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKpS9pd1neL8="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpS9pd1oCcY="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKpS9pd1pO9o="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKpS9pd1qejo="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpS9pd1raoc="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpS9pd1sGNY="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpS9pd1t/jM="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKpbJkuiBfIY=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKpbJkeh9o5o="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiCW+o=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkeh9o5o="
+									},
+									"font": "Arial;13;0",
+									"left": 675,
+									"top": 1174,
+									"width": 213.53515625,
+									"height": 13,
+									"alpha": 4.788763926782328,
+									"distance": 202.8003944769339,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 1,
+									"text": "+Results are made of these Statuses"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiDeAc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkeh9o5o="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 676,
+									"top": 966,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiEfPk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkeh9o5o="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 693,
+									"top": 1007,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiFTSo=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh+YrI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 905,
+									"top": 1133,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiGSFk=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh+YrI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 896,
+									"top": 1143,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiHPBs=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh+YrI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 922,
+									"top": 1111,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiIZsA=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh/9GM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 905,
+									"top": 885,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiJDyQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh/9GM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 897,
+									"top": 874,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKpbJkuiKykE=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh/9GM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 919,
+									"top": 908,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpbJkuiLuWc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh+YrI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 208,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKpbJkuiMLPA=",
+									"_parent": {
+										"$ref": "AAAAAAFnKpbJkuiBfIY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKpbJkuh/9GM="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 208,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKjVWdZCkax0="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKi5XFJByAvs="
+							},
+							"lineStyle": 1,
+							"points": "935:1139;688:1000;935:895",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKpbJkuiCW+o="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKpbJkuiDeAc="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKpbJkuiEfPk="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKpbJkuiFTSo="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKpbJkuiGSFk="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpbJkuiHPBs="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKpbJkuiIZsA="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKpbJkuiJDyQ="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKpbJkuiKykE="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpbJkuiLuWc="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKpbJkuiMLPA="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnKphmx/RqUsw=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnKphmxvRmnL8="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RruUI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRmnL8="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 440,
+									"top": 345,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RsiPI=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRmnL8="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 455,
+									"top": 341,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RtCIY=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRmnL8="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 411,
+									"top": 352,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RuKAQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRn3ME="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 442,
+									"top": 351,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/Rvp+c=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRn3ME="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 455,
+									"top": 350,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RwScQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRn3ME="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 414,
+									"top": 352,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/Rx3B0=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRoI9I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 439,
+									"top": 340,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/Ryut4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRoI9I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 452,
+									"top": 335,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnKphmx/RzhOs=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRoI9I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 414,
+									"top": 350,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKphmx/R0bxc=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRn3ME="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnKphmx/R1NM4=",
+									"_parent": {
+										"$ref": "AAAAAAFnKphmx/RqUsw="
+									},
+									"model": {
+										"$ref": "AAAAAAFnKphmxvRoI9I="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKiU9E491Jgc="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"lineStyle": 1,
+							"points": "422:335;431:375",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnKphmx/RruUI="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnKphmx/RsiPI="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnKphmx/RtCIY="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnKphmx/RuKAQ="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnKphmx/Rvp+c="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnKphmx/RwScQ="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnKphmx/Rx3B0="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnKphmx/Ryut4="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnKphmx/RzhOs="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnKphmx/R0bxc="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnKphmx/R1NM4="
+							}
+						},
+						{
+							"_type": "UMLDependencyView",
+							"_id": "AAAAAAFnRKWwz3J4xus=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnRKWwznJ2Dq0="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnRKWw0HJ5pNQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"model": {
+										"$ref": "AAAAAAFnRKWwznJ2Dq0="
+									},
+									"font": "Arial;13;0",
+									"left": 1223,
+									"top": 815,
+									"width": 299.50146484375,
+									"height": 13,
+									"alpha": -0.7167064198479531,
+									"distance": 442.9864557748916,
+									"hostEdge": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"edgePosition": 1,
+									"text": "+Game creates Result variable for the playerattacks"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnRKWw0HJ62os=",
+									"_parent": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"model": {
+										"$ref": "AAAAAAFnRKWwznJ2Dq0="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 1694,
+									"top": 481,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnRKWw0HJ7GVU=",
+									"_parent": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"model": {
+										"$ref": "AAAAAAFnRKWwznJ2Dq0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1649,
+									"top": 482,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnRKWwz3J4xus="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKjVWdZCkax0="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKhoADY6po7o="
+							},
+							"lineStyle": 1,
+							"points": "1279:139;1664:120;1664:856;1168:848",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnRKWw0HJ5pNQ="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnRKWw0HJ62os="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnRKWw0HJ7GVU="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnROR5N24Qc58=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnROR5Nm4MLMk="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24RLqs=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4MLMk="
+									},
+									"font": "Arial;13;0",
+									"left": 832,
+									"top": 231,
+									"width": 175.95068359375,
+									"height": 13,
+									"alpha": -3.2092635034231662,
+									"distance": 181.54062906137568,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 1,
+									"text": "+The Game instantiates ships."
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24SA94=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4MLMk="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 1100,
+									"top": 216,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24TXnE=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4MLMk="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1099,
+									"top": 260,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24UHC0=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4NwwU="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 493,
+									"top": 183,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24VYPA=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4NwwU="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 498,
+									"top": 170,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24WVR4=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4NwwU="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 483,
+									"top": 209,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24X2aE=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4OGX0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1298,
+									"top": 185,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24YpzE=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4OGX0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1295,
+									"top": 198,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnROR5N24Z2WI=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4OGX0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 1303,
+									"top": 157,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnROR5N24aA7U=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4NwwU="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnROR5N24bWJo=",
+									"_parent": {
+										"$ref": "AAAAAAFnROR5N24Qc58="
+									},
+									"model": {
+										"$ref": "AAAAAAFnROR5Nm4OGX0="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKhoADY6po7o="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"lineStyle": 1,
+							"points": "465:198;680:248;1520:256;1279:168",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnROR5N24RLqs="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnROR5N24SA94="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnROR5N24TXnE="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnROR5N24UHC0="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnROR5N24VYPA="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnROR5N24WVR4="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnROR5N24X2aE="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnROR5N24YpzE="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnROR5N24Z2WI="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnROR5N24aA7U="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnROR5N24bWJo="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnYRzX23AjCJ8=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnYRzX23AkDoQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnYRzX23AjCJ8="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYRzX2nAhjv8="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYRzX23Al/A8=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AkDoQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -112,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYRzX23Am7ck=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AkDoQ="
+											},
+											"font": "Arial;13;1",
+											"left": 197,
+											"top": 927,
+											"width": 114.54345703125,
+											"height": 13,
+											"text": "Weapon"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYRzX23An3eE=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AkDoQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -112,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYRzX23AobUM=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AkDoQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -112,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 192,
+									"top": 920,
+									"width": 124.54345703125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnYRzX23Al/A8="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnYRzX23Am7ck="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnYRzX23An3eE="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnYRzX23AobUM="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnYRzX23ApIxk=",
+									"_parent": {
+										"$ref": "AAAAAAFnYRzX23AjCJ8="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYRzX2nAhjv8="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnYR3IKHZgiq4=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23ApIxk="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYR3IAHY84w4="
+											},
+											"font": "Arial;13;0",
+											"left": 197,
+											"top": 950,
+											"width": 114.54345703125,
+											"height": 13,
+											"text": "-name",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnYSpNZXsLgXs=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23ApIxk="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYSpNPXrn6mE="
+											},
+											"font": "Arial;13;0",
+											"left": 197,
+											"top": 965,
+											"width": 114.54345703125,
+											"height": 13,
+											"text": "-canPenetrate",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 192,
+									"top": 945,
+									"width": 124.54345703125,
+									"height": 38
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnYRzX23AqatU=",
+									"_parent": {
+										"$ref": "AAAAAAFnYRzX23AjCJ8="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYRzX2nAhjv8="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYSuoSoGGAwc=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AqatU="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYSuoJIFigsc="
+											},
+											"font": "Arial;13;0",
+											"left": 197,
+											"top": 988,
+											"width": 114.54345703125,
+											"height": 13,
+											"text": "+getName()",
+											"horizontalAlignment": 0
+										},
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYSviUIPfGpk=",
+											"_parent": {
+												"$ref": "AAAAAAFnYRzX23AqatU="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYSviKYO70cU="
+											},
+											"font": "Arial;13;0",
+											"left": 197,
+											"top": 1003,
+											"width": 114.54345703125,
+											"height": 13,
+											"text": "+getCanPenetrate()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 192,
+									"top": 983,
+									"width": 124.54345703125,
+									"height": 38
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnYRzX23ArIpg=",
+									"_parent": {
+										"$ref": "AAAAAAFnYRzX23AjCJ8="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYRzX2nAhjv8="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"top": -56,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnYRzX23As+jU=",
+									"_parent": {
+										"$ref": "AAAAAAFnYRzX23AjCJ8="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYRzX2nAhjv8="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"top": -56,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 192,
+							"top": 920,
+							"width": 124.54345703125,
+							"height": 101,
+							"autoResize": true,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnYRzX23AkDoQ="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnYRzX23ApIxk="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnYRzX23AqatU="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnYRzX23ArIpg="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnYRzX23As+jU="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnYSxoG4isLdY=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYSxoG4iqSiY="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnYSxoHIituT8=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSxoG4isLdY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSxoG4iqSiY="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSxoHIiukBQ=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSxoHIituT8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSxoHIiv3GM=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSxoHIituT8="
+											},
+											"font": "Arial;13;1",
+											"left": 149,
+											"top": 1191,
+											"width": 98.39501953125,
+											"height": 13,
+											"text": "BombWeapon"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSxoHIiwjj8=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSxoHIituT8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSxoHIixg+A=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSxoHIituT8="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 1184,
+									"width": 108.39501953125,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnYSxoHIiukBQ="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnYSxoHIiv3GM="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnYSxoHIiwjj8="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnYSxoHIixg+A="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnYSxoHIiysMY=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSxoG4isLdY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSxoG4iqSiY="
+									},
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 1209,
+									"width": 108.39501953125,
+									"height": 10
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnYSxoHIizi/o=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSxoG4isLdY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSxoG4iqSiY="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYS8aCqhjHew=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSxoHIizi/o="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYS8Z5ag/SWs="
+											},
+											"font": "Arial;13;0",
+											"left": 149,
+											"top": 1224,
+											"width": 98.39501953125,
+											"height": 13,
+											"text": "+BombWeapon()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 144,
+									"top": 1219,
+									"width": 108.39501953125,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnYSxoHIi0nvc=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSxoG4isLdY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSxoG4iqSiY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnYSxoHIi1E/A=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSxoG4isLdY="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSxoG4iqSiY="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 144,
+							"top": 1184,
+							"width": 108.39501953125,
+							"height": 58,
+							"autoResize": true,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnYSxoHIituT8="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnYSxoHIiysMY="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnYSxoHIizi/o="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnYSxoHIi0nvc="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnYSxoHIi1E/A="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnYSx02om8MAo=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYSx02om6y3c="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnYSx02om9bwQ=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSx02om8MAo="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSx02om6y3c="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSx02om+yQM=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSx02om9bwQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -48,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSx02om/z98=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSx02om9bwQ="
+											},
+											"font": "Arial;13;1",
+											"left": 277,
+											"top": 1183,
+											"width": 133.81494140625,
+											"height": 13,
+											"text": "SpaceLaserWeapon"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSx02onAifA=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSx02om9bwQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -48,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYSx02onB6VY=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSx02om9bwQ="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"top": -48,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 272,
+									"top": 1176,
+									"width": 143.81494140625,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnYSx02om+yQM="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnYSx02om/z98="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnYSx02onAifA="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnYSx02onB6VY="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnYSx02onC07A=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSx02om8MAo="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSx02om6y3c="
+									},
+									"font": "Arial;13;0",
+									"left": 272,
+									"top": 1201,
+									"width": 143.81494140625,
+									"height": 10
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnYSx02onDyWc=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSx02om8MAo="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSx02om6y3c="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYS8+Xan2iDg=",
+											"_parent": {
+												"$ref": "AAAAAAFnYSx02onDyWc="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYS8+OKnS+B8="
+											},
+											"font": "Arial;13;0",
+											"left": 277,
+											"top": 1216,
+											"width": 133.81494140625,
+											"height": 13,
+											"text": "+SpaceLaserWeapon()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 272,
+									"top": 1211,
+									"width": 143.81494140625,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnYSx02onEH8U=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSx02om8MAo="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSx02om6y3c="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"top": -24,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnYSx02onFGyE=",
+									"_parent": {
+										"$ref": "AAAAAAFnYSx02om8MAo="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYSx02om6y3c="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"top": -24,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 272,
+							"top": 1176,
+							"width": 143.81494140625,
+							"height": 58,
+							"autoResize": true,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnYSx02om9bwQ="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnYSx02onC07A="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnYSx02onDyWc="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnYSx02onEH8U="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnYSx02onFGyE="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnYTAxCrRwpDA=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYTAxCrRuCgs="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTAxCrRxdvY=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTAxCrRuCgs="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 207,
+									"top": 1092,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTAxCrRyIgE=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTAxCrRuCgs="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 192,
+									"top": 1089,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTAxC7RzbTw=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTAxCrRuCgs="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 236,
+									"top": 1099,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTAxCrRwpDA="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnYRzX23AjCJ8="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnYSxoG4isLdY="
+							},
+							"lineStyle": 1,
+							"points": "204:1183;241:1021",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnYTAxCrRxdvY="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnYTAxCrRyIgE="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnYTAxC7RzbTw="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnYTBCBrWJZiM=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYTBCBrWHZqE="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTBCBrWKtik=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTBCBrWHZqE="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 287,
+									"top": 1097,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTBCBrWLg50=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTBCBrWHZqE="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 273,
+									"top": 1102,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTBCBrWMHvg=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTBCBrWHZqE="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 316,
+									"top": 1086,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTBCBrWJZiM="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnYRzX23AjCJ8="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnYSx02om8MAo="
+							},
+							"lineStyle": 1,
+							"points": "332:1175;273:1021",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnYTBCBrWKtik="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnYTBCBrWLg50="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnYTBCBrWMHvg="
+							}
+						},
+						{
+							"_type": "UMLAssociationView",
+							"_id": "AAAAAAFnYTI+ZcQ9O4Y=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZcQ+ph4=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 355,
+									"top": 869,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZcQ/tAM=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 366,
+									"top": 879,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZcRA97U=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 332,
+									"top": 850,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZcRB5Xc=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ6tAQ="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 385,
+									"top": 836,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZcRCvRo=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ6tAQ="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 393,
+									"top": 846,
+									"height": 13,
+									"alpha": 0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 2
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZsRDKZo=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ6tAQ="
+									},
+									"font": "Arial;13;0",
+									"left": 364,
+									"top": 815,
+									"width": 7.22998046875,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"edgePosition": 2,
+									"text": "1"
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZsREvl8=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ7XIk="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 326,
+									"top": 903,
+									"height": 13,
+									"alpha": -0.5235987755982988,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZsRFAVg=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ7XIk="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 337,
+									"top": 910,
+									"height": 13,
+									"alpha": -0.7853981633974483,
+									"distance": 40,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									}
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTI+ZsRGXPY=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ7XIk="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 302,
+									"top": 888,
+									"height": 13,
+									"alpha": 0.5235987755982988,
+									"distance": 25,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									}
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnYTI+ZsRH2u4=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ6tAQ="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLQualifierCompartmentView",
+									"_id": "AAAAAAFnYTI+ZsRITT4=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTI+ZcQ9O4Y="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTI+ZcQ7XIk="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnYRzX23AjCJ8="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnKiU9E491Jgc="
+							},
+							"lineStyle": 1,
+							"points": "391:813;298:919",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnYTI+ZcQ+ph4="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnYTI+ZcQ/tAM="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnYTI+ZcRA97U="
+							},
+							"tailRoleNameLabel": {
+								"$ref": "AAAAAAFnYTI+ZcRB5Xc="
+							},
+							"tailPropertyLabel": {
+								"$ref": "AAAAAAFnYTI+ZcRCvRo="
+							},
+							"tailMultiplicityLabel": {
+								"$ref": "AAAAAAFnYTI+ZsRDKZo="
+							},
+							"headRoleNameLabel": {
+								"$ref": "AAAAAAFnYTI+ZsREvl8="
+							},
+							"headPropertyLabel": {
+								"$ref": "AAAAAAFnYTI+ZsRFAVg="
+							},
+							"headMultiplicityLabel": {
+								"$ref": "AAAAAAFnYTI+ZsRGXPY="
+							},
+							"tailQualifiersCompartment": {
+								"$ref": "AAAAAAFnYTI+ZsRH2u4="
+							},
+							"headQualifiersCompartment": {
+								"$ref": "AAAAAAFnYTI+ZsRITT4="
+							}
+						},
+						{
+							"_type": "UMLClassView",
+							"_id": "AAAAAAFnYTYFqtDYD2c=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYTYFqtDWBhg="
+							},
+							"subViews": [
+								{
+									"_type": "UMLNameCompartmentView",
+									"_id": "AAAAAAFnYTYFq9DZkvs=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTYFqtDYD2c="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTYFqtDWBhg="
+									},
+									"subViews": [
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYTYFq9DaeB8=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9DZkvs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": 16,
+											"height": 13
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYTYFq9DbH+o=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9DZkvs="
+											},
+											"font": "Arial;13;1",
+											"left": 21,
+											"top": 47,
+											"width": 103,
+											"height": 13,
+											"text": "Submarine"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYTYFq9DcySs=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9DZkvs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": 16,
+											"width": 73.67724609375,
+											"height": 13,
+											"text": "(from Model)"
+										},
+										{
+											"_type": "LabelView",
+											"_id": "AAAAAAFnYTYFq9Dd7YY=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9DZkvs="
+											},
+											"visible": false,
+											"font": "Arial;13;0",
+											"left": -96,
+											"top": 16,
+											"height": 13,
+											"horizontalAlignment": 1
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 16,
+									"top": 40,
+									"width": 113,
+									"height": 25,
+									"stereotypeLabel": {
+										"$ref": "AAAAAAFnYTYFq9DaeB8="
+									},
+									"nameLabel": {
+										"$ref": "AAAAAAFnYTYFq9DbH+o="
+									},
+									"namespaceLabel": {
+										"$ref": "AAAAAAFnYTYFq9DcySs="
+									},
+									"propertyLabel": {
+										"$ref": "AAAAAAFnYTYFq9Dd7YY="
+									}
+								},
+								{
+									"_type": "UMLAttributeCompartmentView",
+									"_id": "AAAAAAFnYTYFq9DeKkU=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTYFqtDYD2c="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTYFqtDWBhg="
+									},
+									"subViews": [
+										{
+											"_type": "UMLAttributeView",
+											"_id": "AAAAAAFnYTfq/t1kFUo=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9DeKkU="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTfq0t09Vns="
+											},
+											"font": "Arial;13;0",
+											"left": 21,
+											"top": 70,
+											"width": 103,
+											"height": 13,
+											"text": "+submerged",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 16,
+									"top": 65,
+									"width": 113,
+									"height": 23
+								},
+								{
+									"_type": "UMLOperationCompartmentView",
+									"_id": "AAAAAAFnYTYFq9Df864=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTYFqtDYD2c="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTYFqtDWBhg="
+									},
+									"subViews": [
+										{
+											"_type": "UMLOperationView",
+											"_id": "AAAAAAFnYTb069jvgvU=",
+											"_parent": {
+												"$ref": "AAAAAAFnYTYFq9Df864="
+											},
+											"model": {
+												"$ref": "AAAAAAFnYTb0wtjIqqc="
+											},
+											"font": "Arial;13;0",
+											"left": 21,
+											"top": 93,
+											"width": 103,
+											"height": 13,
+											"text": "+Submarine()",
+											"horizontalAlignment": 0
+										}
+									],
+									"font": "Arial;13;0",
+									"left": 16,
+									"top": 88,
+									"width": 113,
+									"height": 23
+								},
+								{
+									"_type": "UMLReceptionCompartmentView",
+									"_id": "AAAAAAFnYTYFq9DgBrw=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTYFqtDYD2c="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTYFqtDWBhg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -48,
+									"top": 8,
+									"width": 10,
+									"height": 10
+								},
+								{
+									"_type": "UMLTemplateParameterCompartmentView",
+									"_id": "AAAAAAFnYTYFq9DhPDY=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTYFqtDYD2c="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTYFqtDWBhg="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": -48,
+									"top": 8,
+									"width": 10,
+									"height": 10
+								}
+							],
+							"font": "Arial;13;0",
+							"containerChangeable": true,
+							"left": 16,
+							"top": 40,
+							"width": 113,
+							"height": 71,
+							"nameCompartment": {
+								"$ref": "AAAAAAFnYTYFq9DZkvs="
+							},
+							"attributeCompartment": {
+								"$ref": "AAAAAAFnYTYFq9DeKkU="
+							},
+							"operationCompartment": {
+								"$ref": "AAAAAAFnYTYFq9Df864="
+							},
+							"receptionCompartment": {
+								"$ref": "AAAAAAFnYTYFq9DgBrw="
+							},
+							"templateParameterCompartment": {
+								"$ref": "AAAAAAFnYTYFq9DhPDY="
+							}
+						},
+						{
+							"_type": "UMLGeneralizationView",
+							"_id": "AAAAAAFnYTc2zdru5IE=",
+							"_parent": {
+								"$ref": "AAAAAAFF+qBtyKM79qY="
+							},
+							"model": {
+								"$ref": "AAAAAAFnYTc2zdrs5bI="
+							},
+							"subViews": [
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTc2zdrv1dI=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTc2zdrs5bI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 220,
+									"top": 102,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTc2zdrwVjo=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTc2zdrs5bI="
+									},
+									"visible": null,
+									"font": "Arial;13;0",
+									"left": 225,
+									"top": 88,
+									"height": 13,
+									"alpha": 1.5707963267948966,
+									"distance": 30,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"edgePosition": 1
+								},
+								{
+									"_type": "EdgeLabelView",
+									"_id": "AAAAAAFnYTc2zdrxE5E=",
+									"_parent": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"model": {
+										"$ref": "AAAAAAFnYTc2zdrs5bI="
+									},
+									"visible": false,
+									"font": "Arial;13;0",
+									"left": 211,
+									"top": 131,
+									"height": 13,
+									"alpha": -1.5707963267948966,
+									"distance": 15,
+									"hostEdge": {
+										"$ref": "AAAAAAFnYTc2zdru5IE="
+									},
+									"edgePosition": 1
+								}
+							],
+							"font": "Arial;13;0",
+							"head": {
+								"$ref": "AAAAAAFnKfWFh4wMF3A="
+							},
+							"tail": {
+								"$ref": "AAAAAAFnYTYFqtDYD2c="
+							},
+							"lineStyle": 1,
+							"points": "129:94;303:152",
+							"showVisibility": true,
+							"nameLabel": {
+								"$ref": "AAAAAAFnYTc2zdrv1dI="
+							},
+							"stereotypeLabel": {
+								"$ref": "AAAAAAFnYTc2zdrwVjo="
+							},
+							"propertyLabel": {
+								"$ref": "AAAAAAFnYTc2zdrxE5E="
+							}
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKfWFhowKE2I=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Ship",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKkvC95ERAIE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "0..*",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKkvC95ESElY=",
+								"_parent": {
+									"$ref": "AAAAAAFnKkvC95ERAIE="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKkvC95ETHFU=",
+								"_parent": {
+									"$ref": "AAAAAAFnKkvC95ERAIE="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKgZYZ42c42w="
+								},
+								"aggregation": "shared"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKk41opH2wNY=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "is made of",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKk41opH30lA=",
+								"_parent": {
+									"$ref": "AAAAAAFnKk41opH2wNY="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKk41opH4ml8=",
+								"_parent": {
+									"$ref": "AAAAAAFnKk41opH2wNY="
+								},
+								"name": "0...*",
+								"reference": {
+									"$ref": "AAAAAAFnKgZYZ42c42w="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKphmxvRmnL8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKphmxvRn3ME=",
+								"_parent": {
+									"$ref": "AAAAAAFnKphmxvRmnL8="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKphmxvRoI9I=",
+								"_parent": {
+									"$ref": "AAAAAAFnKphmxvRmnL8="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKpiv6PX5688=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpiv6PX68k4=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpiv6PX5688="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpiv6PX7oJM=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpiv6PX5688="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKgnLy44aKsg="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnROR5Nm4MLMk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "The Game instantiates ships.",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnROR5Nm4NwwU=",
+								"_parent": {
+									"$ref": "AAAAAAFnROR5Nm4MLMk="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnROR5Nm4OGX0=",
+								"_parent": {
+									"$ref": "AAAAAAFnROR5Nm4MLMk="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKhoADY6nCLQ="
+								},
+								"aggregation": "composite"
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKfnKPIw+gHs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "Health",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKfng/YxFqIk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "length",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKfoe7YxMLvk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "armor",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKfph/oxVIE0=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "shipType",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfqjl4xl9rs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "Ship"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfq854xsm80=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "Ship",
+							"parameters": [
+								{
+									"_type": "UMLParameter",
+									"_id": "AAAAAAFnKfrasoxz0do=",
+									"_parent": {
+										"$ref": "AAAAAAFnKfq854xsm80="
+									},
+									"name": "kind",
+									"type": ""
+								}
+							]
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfu+J4x1NAg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "getOccupiedSquares"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfviT4x864A=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "setOccupiedSquares"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfwHn4yDk2g=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "getLength"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfwi8IyK5m8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "getShipType"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfw9OoyRT8U=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "decrementHealth"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfxzaIyjlPo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "forceSink"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfyBtIyqOFE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "getHealth"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfyQb4yx8bw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "setArmor"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfyf4oy4RCw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "getArmor"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKfyuqoy/mUU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "Operation1"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYThJE+DtYgs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "canAttackWithWeapon"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUz941wcd/U=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							},
+							"name": "checkAndUpdateForHit"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKfzYa4zFWdM=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Minesweeper",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnKfzY1Yzu31o=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfzYa4zFWdM="
+							},
+							"source": {
+								"$ref": "AAAAAAFnKfzYa4zFWdM="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgERqY2Nloo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfzYa4zFWdM="
+							},
+							"name": "Minesweeper"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKfzzg4z/MyY=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Battleship",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnKfzz9o0o4bA=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfzzg4z/MyY="
+							},
+							"source": {
+								"$ref": "AAAAAAFnKfzzg4z/MyY="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgEC8Y2GRS8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfzzg4z/MyY="
+							},
+							"name": "Battleship"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKfz1Eo05V4c=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Destroyer",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnKfz1eo1iepg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfz1Eo05V4c="
+							},
+							"source": {
+								"$ref": "AAAAAAFnKfz1Eo05V4c="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgDPUY1+Xf8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKfz1Eo05V4c="
+							},
+							"name": "Destroyer"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKgZYZ42c42w=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Square",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKpNt3do9VLg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Ships are made of squares",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpNt3to+IEw=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpNt3do9VLg="
+								},
+								"name": "2...*",
+								"reference": {
+									"$ref": "AAAAAAFnKgZYZ42c42w="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpNt3to/dS0=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpNt3do9VLg="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKfWFhowKE2I="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKpS9pd1eZ44=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Board is made of squares",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpS9pd1fByg=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpS9pd1eZ44="
+								},
+								"name": "10x10",
+								"reference": {
+									"$ref": "AAAAAAFnKgZYZ42c42w="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpS9pd1gns0=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpS9pd1eZ44="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								},
+								"aggregation": "composite"
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKgZxWI3GcGo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Row",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKgaC1I3NW14=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Column",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKgaYuo3UIUY=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Captain",
+							"visibility": "private",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgbcwY3i3uk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Square",
+							"parameters": [
+								{
+									"_type": "UMLParameter",
+									"_id": "AAAAAAFnKgcVSI3vmqg=",
+									"_parent": {
+										"$ref": "AAAAAAFnKgbcwY3i3uk="
+									},
+									"name": "default",
+									"type": ""
+								}
+							]
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgb4iI3opzs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "Square"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgd7yY3zmIU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "getColumn"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgeUlY36abw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "setColumn"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgeuAY4Buv8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "setCaptainsQuarters"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgfNyI4IZac=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "getRow"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgf9T44S3ns=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgZYZ42c42w="
+							},
+							"name": "setRow"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKgnLy44aKsg=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "PlaceUtility",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKmK3qpt3g6I=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgnLy44aKsg="
+							},
+							"name": "scans and places on",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmK3qpt4dRw=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmK3qpt3g6I="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKgnLy44aKsg="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmK3qpt533c=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmK3qpt3g6I="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								}
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKmyEVK++Ii0=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgnLy44aKsg="
+							},
+							"name": "Board calls Place",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmyEVK+/mHc=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmyEVK++Ii0="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKgnLy44aKsg="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmyEVK/AZPM=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmyEVK++Ii0="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								},
+								"aggregation": "composite"
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKgnofo5El8k=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgnLy44aKsg="
+							},
+							"name": "place"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhkL4Y5LTiA=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgnLy44aKsg="
+							},
+							"name": "checkToMakecaptainsQuarters"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhk1Bo5Szfs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKgnLy44aKsg="
+							},
+							"name": "is_duplicate_ship"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKhoADY6nCLQ=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Game",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKlDm9ZWqgrU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "The Game creates two separate boards",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKlDm9ZWr24Y=",
+								"_parent": {
+									"$ref": "AAAAAAFnKlDm9ZWqgrU="
+								},
+								"name": "2",
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKlDm9ZWsajo=",
+								"_parent": {
+									"$ref": "AAAAAAFnKlDm9ZWqgrU="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKhoADY6nCLQ="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKmgg1qSL3ig=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmgg1qSMYPw=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmgg1qSL3ig="
+								},
+								"name": "accesses",
+								"reference": {
+									"$ref": "AAAAAAFnKhoADY6nCLQ="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmgg1qSNfuk=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmgg1qSL3ig="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKgnLy44aKsg="
+								}
+							}
+						},
+						{
+							"_type": "UMLDependency",
+							"_id": "AAAAAAFnRKWwznJ2Dq0=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "Game creates Result variable for the playerattacks",
+							"source": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							}
+						},
+						{
+							"_type": "UMLDependency",
+							"_id": "AAAAAAFnRM8S7aIkmJQ=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "Game creates ships and sends them to the board.",
+							"source": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						},
+						{
+							"_type": "UMLDependency",
+							"_id": "AAAAAAFnRNqqml0PuzE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"source": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKhou3I7R4Yw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "playersBoard",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKhpXxI7Yxf4=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "opponentsBoard",
+							"visibility": "private",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhqKdY7g//M=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "placeShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhqa5o7naUM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "attack"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhquKY7uu1c=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "sonar"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhrCaI71DDI=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "randCol"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhrOfI78JWE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "randRow"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhsh948DWkk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "randVertical"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhs1II8KW8I=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "getPlayersBoard"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKhtZFo8Ryaw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "getOpponentsBoard"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYTl17+gj2XM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKhoADY6nCLQ="
+							},
+							"name": "moveFleet"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKiU9E49z87Q=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Board",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKk9HAJObxnQ=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "is made of",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKk9HAJOcwX0=",
+								"_parent": {
+									"$ref": "AAAAAAFnKk9HAJObxnQ="
+								},
+								"name": "1",
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKk9HAJOdixA=",
+								"_parent": {
+									"$ref": "AAAAAAFnKk9HAJObxnQ="
+								},
+								"name": "10x10",
+								"reference": {
+									"$ref": "AAAAAAFnKgZYZ42c42w="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnYTI+ZMQ5ZLs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnYTI+ZcQ6tAQ=",
+								"_parent": {
+									"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								},
+								"multiplicity": "1"
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnYTI+ZcQ7XIk=",
+								"_parent": {
+									"$ref": "AAAAAAFnYTI+ZMQ5ZLs="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnYRzX2nAhjv8="
+								}
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiWXRI+fqd8=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "boardarray",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiWtYo+mjeg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "occupied",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiXNG4+t/Bs=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "sonarEnabled",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiX51o+1J6k=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "sonarCount",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiYXU4+8jNg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "BOARDSIZE_X",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiZAbY/Dmcc=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "BOARDSIZE_Y",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiZOp4/KnKg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "ships",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKiZkJI/Ra7c=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "attacks",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnYTFQs76DMLU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "currentWeapon",
+							"visibility": "private",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKiapVY/hxqM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "Board"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKibKEY/oYAk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "areCoordinatesOnBoard"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKib5LI/v4Y4=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "isOccupied"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKicaDY/2dWU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getSquare"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKicmu4/9xVU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "placeShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKic26JAEo+4=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "attack"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKidC65ALMOk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "sonar"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKidVH5ASE7A=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getShips"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKidkYJAZK6Y=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setShips"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKidyeZAg4Ew=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "addShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKieeNpAodGc=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "removeShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKie06ZAvZVY=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getAttacks"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKifKkJA2Diw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "addAttack"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKifg4JA96Ho=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "addAttacks"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKif+qpBEbJw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setAttacks"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKigfBpBLjSc=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setOccupied",
+							"visibility": "private"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKig7h5BSysE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setSonarEnabled"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKihS8pBZvMU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getSonarEnabled"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKih8w5Bhgj0=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setSonarCount"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKiiRuZBohSo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getSonarCount"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYTqWsgGebiM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getCurrentWeapon"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYTq+NQNV5B0=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "setCurrentWeapon"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUSaCCrX3yk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "checkToMakeCaptainsQuarters",
+							"visibility": "private"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUTRDyyOCYo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "is_duplicate_ship",
+							"visibility": "private"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUT5vy5FFRM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "getSonarHitSquare",
+							"visibility": "private"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUfIeUoeMYI=",
+							"_parent": {
+								"$ref": "AAAAAAFnKiU9E49z87Q="
+							},
+							"name": "moveFleet"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKi5XE5Bw7yY=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "AttackStatus",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKpbJkeh9o5o=",
+							"_parent": {
+								"$ref": "AAAAAAFnKi5XE5Bw7yY="
+							},
+							"name": "Results are made of these Statuses",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpbJkuh+YrI=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpbJkeh9o5o="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKi5XE5Bw7yY="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKpbJkuh/9GM=",
+								"_parent": {
+									"$ref": "AAAAAAFnKpbJkeh9o5o="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKjVWdZCibOY="
+								},
+								"aggregation": "composite"
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKi6TQ5CaYuI=",
+							"_parent": {
+								"$ref": "AAAAAAFnKi5XE5Bw7yY="
+							},
+							"name": "AttackStatus",
+							"type": ""
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnKjVWdZCibOY=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Result",
+					"ownedElements": [
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKmvHuK044Yg=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "is made of",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmvHuK05MWg=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmvHuK044Yg="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKi5XE5Bw7yY="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKmvHuK06ht0=",
+								"_parent": {
+									"$ref": "AAAAAAFnKmvHuK044Yg="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKjVWdZCibOY="
+								},
+								"aggregation": "composite"
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKm/Y5cLkHxc=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "uses",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKm/Y5cLlBcQ=",
+								"_parent": {
+									"$ref": "AAAAAAFnKm/Y5cLkHxc="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKjVWdZCibOY="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKm/Y5cLmSKc=",
+								"_parent": {
+									"$ref": "AAAAAAFnKm/Y5cLkHxc="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKhoADY6nCLQ="
+								}
+							}
+						},
+						{
+							"_type": "UMLAssociation",
+							"_id": "AAAAAAFnKnzfMtAr67k=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "Board creates a result array.",
+							"end1": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKnzfMtAs8+M=",
+								"_parent": {
+									"$ref": "AAAAAAFnKnzfMtAr67k="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKjVWdZCibOY="
+								}
+							},
+							"end2": {
+								"_type": "UMLAssociationEnd",
+								"_id": "AAAAAAFnKnzfMtAtA94=",
+								"_parent": {
+									"$ref": "AAAAAAFnKnzfMtAr67k="
+								},
+								"reference": {
+									"$ref": "AAAAAAFnKiU9E49z87Q="
+								},
+								"aggregation": "composite"
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKjm3XJDMVuM=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "attackStatus",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKjnOhZDTvsc=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "sShip",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnKjn9TpDa5LE=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "loc",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjpBXZDjufU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "getResult"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjpUMpDqO9Y=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "setResult"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjpihJDxUUY=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "getShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjqRGZD5/yk=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "setShip"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjqcDpEAFVo=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "getLocation"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnKjq6X5EH0yw=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "setLocation"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUrC71b4uEQ=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "isResultSpaceAlreadyAttacked"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYUs0XFj3ZdU=",
+							"_parent": {
+								"$ref": "AAAAAAFnKjVWdZCibOY="
+							},
+							"name": "wasSpaceFormerlyArmoredCaptain"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnYRzX2nAhjv8=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Weapon",
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnYR3IAHY84w4=",
+							"_parent": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							},
+							"name": "name",
+							"visibility": "private",
+							"type": ""
+						},
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnYSpNPXrn6mE=",
+							"_parent": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							},
+							"name": "canPenetrate",
+							"visibility": "private",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYSuoJIFigsc=",
+							"_parent": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							},
+							"name": "getName"
+						},
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYSviKYO70cU=",
+							"_parent": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							},
+							"name": "getCanPenetrate"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnYSxoG4iqSiY=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "BombWeapon",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnYTAxCrRuCgs=",
+							"_parent": {
+								"$ref": "AAAAAAFnYSxoG4iqSiY="
+							},
+							"source": {
+								"$ref": "AAAAAAFnYSxoG4iqSiY="
+							},
+							"target": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYS8Z5ag/SWs=",
+							"_parent": {
+								"$ref": "AAAAAAFnYSxoG4iqSiY="
+							},
+							"name": "BombWeapon"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnYSx02om6y3c=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "SpaceLaserWeapon",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnYTBCBrWHZqE=",
+							"_parent": {
+								"$ref": "AAAAAAFnYSx02om6y3c="
+							},
+							"source": {
+								"$ref": "AAAAAAFnYSx02om6y3c="
+							},
+							"target": {
+								"$ref": "AAAAAAFnYRzX2nAhjv8="
+							}
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYS8+OKnS+B8=",
+							"_parent": {
+								"$ref": "AAAAAAFnYSx02om6y3c="
+							},
+							"name": "SpaceLaserWeapon"
+						}
+					]
+				},
+				{
+					"_type": "UMLClass",
+					"_id": "AAAAAAFnYTYFqtDWBhg=",
+					"_parent": {
+						"$ref": "AAAAAAFF+qBWK6M3Z8Y="
+					},
+					"name": "Submarine",
+					"ownedElements": [
+						{
+							"_type": "UMLGeneralization",
+							"_id": "AAAAAAFnYTc2zdrs5bI=",
+							"_parent": {
+								"$ref": "AAAAAAFnYTYFqtDWBhg="
+							},
+							"source": {
+								"$ref": "AAAAAAFnYTYFqtDWBhg="
+							},
+							"target": {
+								"$ref": "AAAAAAFnKfWFhowKE2I="
+							}
+						}
+					],
+					"attributes": [
+						{
+							"_type": "UMLAttribute",
+							"_id": "AAAAAAFnYTfq0t09Vns=",
+							"_parent": {
+								"$ref": "AAAAAAFnYTYFqtDWBhg="
+							},
+							"name": "submerged",
+							"type": ""
+						}
+					],
+					"operations": [
+						{
+							"_type": "UMLOperation",
+							"_id": "AAAAAAFnYTb0wtjIqqc=",
+							"_parent": {
+								"$ref": "AAAAAAFnYTYFqtDWBhg="
+							},
+							"name": "Submarine"
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
This adds a class UML to describe the layout of the application after our changes for sprint 4. Note that I've removed the *Utility classes as noted by Caius in the last sprint. Instead I've pushed some of the related functions down to other classes, such as in Result, Square and Ship. Additional functionality internally to each method in Board may be further able to be pushed down this way to clean up the board.

The major changes beyond removing the 3 utility classes include:
- Adding in a base **Weapon** class with **BombWeapon** and **SpaceLaserWeapon** classes
- Added a **currentWeapon** to **Board**, this will be the weapon used during attacks
- Added **getCanPenetrate** to 'Weapon', which indicates whether the weapon can penetrate or not This should be used when attacking a ship to determine if the ship can or can't be damaged in it's current state (such as when a submarine is submerged)
- Added **Submarine** class, with a property of submerged
- Pushed **checkAndUpdateForHit** to the **Ship** class (away from the board). Each ship will manage it's own logic for whether it can be hit with the current weapon, and what happens to it as well
- Pushed a couple methods into **Result** for checking if a space was already attacked and if a space was formerly an armored captain's quarters
- Added **moveFleet** methods to **Game** and **Board** respectively

Let me know if this looks ok. Should suffice, and we can adjust the file as we go.